### PR TITLE
docs: generalize README path examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,16 @@ uvicorn main:app --host 0.0.0.0 --port 5000 --reload
 ### Terminal B — Node backend (port 4000)
 
 ```bash
-cd /workspaces/pdf-qa-bot
+# from the repository root (where server.js lives)
+cd <your-repo-directory>
 node server.js
 ```
 
 ### Terminal C — Frontend (port 3000)
 
 ```bash
-cd /workspaces/pdf-qa-bot/frontend
+# navigate into the frontend subfolder from the repo root
+cd frontend
 npm start
 ```
 
@@ -119,4 +121,4 @@ Interactive docs: `http://localhost:5000/docs`
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+Refer to [CONTRIBUTING.md](CONTRIBUTING.md) for detailed instructions on creating a branch, naming conventions, committing changes, and submitting pull requests.


### PR DESCRIPTION
### Team Number : Team 132

### Description
This PR generalizes the documentation by replacing hardcoded absolute workspace paths with relative paths and introduces a new step-by-step contribution guide to assist new users with setup and naming standards.

### Related Issue
Closes #36  (Note: Replace with the actual issue number if different)

### Type of Change
Documentation update
### Changes Made
Path Generalization: Updated README.md to use relative paths (e.g., cd frontend) instead of absolute workspace paths, making setup instructions local-environment independent.
Improved Integration: Linked the new guide in README.md for better discoverability.
### Testing
README.md
Checklist
 My code follows the project's code style guidelines
 I have read and followed the CONTRIBUTING.md guidelines
### Additional Notes
These changes solve the issue of personalized setup instructions being confusing for new contributors and provide a more welcoming onboarding experience.
Related Issue:
Closed: #36 