### PR TITLE
fix: resolve cross-user data leakage in FAISS session store

### DIFF
--- a/demo_bug.py
+++ b/demo_bug.py
@@ -1,0 +1,170 @@
+"""
+DEMO: Cross-User Data Leakage — BUG vs FIX
+============================================
+STEP 1: Reproduces the old vulnerable code (no ownership check).
+STEP 2: Runs the fixed code (session bound to user_id, attack blocked).
+"""
+
+import sys, uuid, time, types
+from unittest.mock import MagicMock
+
+for mod in [
+    "torch", "transformers", "langchain_community", "langchain_text_splitters",
+    "langchain_core", "langchain_community.document_loaders",
+    "langchain_community.vectorstores", "langchain_community.embeddings",
+    "langchain_core.documents", "slowapi", "slowapi.util", "slowapi.errors",
+    "dotenv", "uvicorn",
+]:
+    sys.modules.setdefault(mod, MagicMock())
+
+SEP  = "=" * 70
+DASH = "-" * 70
+
+class FakeVectorStore:
+    def __init__(self, owner, content):
+        self.owner   = owner
+        self.content = content
+    def similarity_search(self, query, k=4):
+        Doc = types.SimpleNamespace
+        return [Doc(page_content=self.content)]
+
+ALICE_SECRET = (
+    "CONFIDENTIAL -- Patient: Alice Smith\n"
+    "Diagnosis: Stage-2 hypertension. Prescribed lisinopril 10mg.\n"
+    "SSN: 123-45-6789. Account balance: $84,320."
+)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# STEP 1 — VULNERABLE (before fix)
+# ──────────────────────────────────────────────────────────────────────────────
+print(SEP)
+print("  STEP 1 — VULNERABLE CODE (before fix)")
+print(SEP)
+
+sessions_bug = {}
+
+def bug_upload(owner_name, content):
+    sid = str(uuid.uuid4())
+    sessions_bug[sid] = {          # NO user_id stored
+        "vectorstores": [FakeVectorStore(owner_name, content)],
+        "last_accessed": time.time(),
+    }
+    return sid
+
+def bug_ask(session_ids, question):
+    docs = []
+    for sid in session_ids:
+        session = sessions_bug.get(sid)   # NO ownership check
+        if session:
+            for vs in session["vectorstores"]:
+                docs.extend(vs.similarity_search(question))
+    if not docs:
+        return "No relevant context found."
+    return "[MODEL ANSWER]:\n" + "\n".join(d.page_content for d in docs)
+
+alice_sid = bug_upload("Alice", ALICE_SECRET)
+bob_sid   = bug_upload("Bob",   "Bob's Q4 revenue report: $1M.")
+
+print(f"\n  Alice session_id : {alice_sid}")
+print(f"  Bob   session_id : {bob_sid}")
+print(f"\n  Bob attacks: POST /ask  session_ids=[alice_sid]  (no auth token needed)")
+print(DASH)
+response = bug_ask([alice_sid], "What is the diagnosis and SSN?")
+print("  SERVER RESPONSE (VULNERABLE):")
+print(response)
+print(DASH)
+print("\n  [!] BUG: Bob received Alice's CONFIDENTIAL data with zero auth.\n")
+
+# ──────────────────────────────────────────────────────────────────────────────
+# STEP 2 — FIXED (after fix)
+# ──────────────────────────────────────────────────────────────────────────────
+print(SEP)
+print("  STEP 2 — FIXED CODE (after fix)")
+print(SEP)
+
+sessions_fix = {}
+
+class User:
+    def __init__(self, uid, name, role="user"):
+        self.id   = uid
+        self.name = name
+        self.role = role
+
+ALICE = User(1, "Alice")
+BOB   = User(2, "Bob")
+
+def fix_upload(user, content):
+    sid = str(uuid.uuid4())
+    sessions_fix[sid] = {
+        "vectorstores": [FakeVectorStore(user.name, content)],
+        "last_accessed": time.time(),
+        "user_id": user.id,          # FIX: ownership stored
+    }
+    return sid
+
+class HTTP403(Exception):
+    pass
+
+def fix_ask(session_ids, question, current_user):
+    docs = []
+    for sid in session_ids:
+        session = sessions_fix.get(sid)
+        if session:
+            # ── OWNERSHIP CHECK (the fix) ──────────────────────────────────
+            if session["user_id"] != current_user.id and current_user.role != "admin":
+                raise HTTP403(
+                    f"403 Forbidden: session '{sid}' belongs to "
+                    f"user_id={session['user_id']}, not user_id={current_user.id}."
+                )
+            # ──────────────────────────────────────────────────────────────
+            session["last_accessed"] = time.time()
+            for vs in session["vectorstores"]:
+                docs.extend(vs.similarity_search(question))
+    if not docs:
+        return "No relevant context found."
+    return "[MODEL ANSWER]:\n" + "\n".join(d.page_content for d in docs)
+
+alice_sid2 = fix_upload(ALICE, ALICE_SECRET)
+bob_sid2   = fix_upload(BOB,   "Bob's Q4 revenue report: $1M.")
+
+print(f"\n  Alice session_id : {alice_sid2}")
+print(f"  Bob   session_id : {bob_sid2}")
+
+# Attack attempt
+print(f"\n  Bob attacks: POST /ask  session_ids=[alice_sid]  (Bob's JWT, Alice's sid)")
+print(DASH)
+try:
+    fix_ask([alice_sid2], "What is the diagnosis and SSN?", BOB)
+    print("  ERROR: Should not reach here!")
+except HTTP403 as e:
+    print(f"  SERVER RESPONSE (FIXED):")
+    print(f"  {e}")
+print(DASH)
+print("\n  [OK] FIXED: Bob's attack is BLOCKED. Alice's data is protected.\n")
+
+# Bob accesses his own session (must still work)
+print("  Bob accesses his OWN session (should succeed) ...")
+print(DASH)
+own = fix_ask([bob_sid2], "What is the revenue?", BOB)
+print(f"  SERVER RESPONSE (Bob's own data):")
+print(own)
+print(DASH)
+print("\n  [OK] Bob can still access his own documents normally.\n")
+
+# ──────────────────────────────────────────────────────────────────────────────
+print(SEP)
+print("  CHANGES MADE IN rag-service/main.py")
+print(SEP)
+print("""
+  /upload    +  current_user = Depends(AuthMiddleware.get_current_user)
+               session["user_id"] = current_user.id   # <<< NEW
+
+  /ask       +  current_user = Depends(AuthMiddleware.get_current_user)
+               if session["user_id"] != current_user.id
+                   and current_user.role != UserRole.ADMIN:
+                   raise HTTP 403 Forbidden              # <<< NEW
+
+  /summarize  — same ownership check as /ask             # <<< NEW
+  /compare    — same ownership check as /ask             # <<< NEW
+""")
+print(SEP)

--- a/rag-service/main.py
+++ b/rag-service/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request, File, UploadFile
+from fastapi import FastAPI, Request, File, UploadFile, Depends, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from langchain_community.document_loaders import PyPDFLoader
@@ -18,15 +18,17 @@ import uuid
 import torch
 import uvicorn
 
-# IMPORTANT: Authentication REMOVED as per issue requirement
-# (Authentication was breaking existing endpoints)
+# Authentication — required to prevent cross-user data leakage
+from auth.middleware import AuthMiddleware
+from auth.models import User, UserRole
+from auth.router import router as auth_router
 
 load_dotenv()
 
 app = FastAPI(
     title="PDF QA Bot API",
-    description="PDF Question-Answering Bot (Session-based, No Auth)",
-    version="2.1.0"
+    description="PDF Question-Answering Bot with session-ownership enforcement",
+    version="2.2.0"
 )
 
 # CORS
@@ -43,10 +45,14 @@ limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+# Auth routes
+app.include_router(auth_router, prefix="/auth", tags=["auth"])
+
 # ===============================
-# SESSION STORAGE (REQUIRED: keep sessionId)
+# SESSION STORAGE
 # ===============================
-# Format: { session_id: { "vectorstores": [FAISS], "last_accessed": float } }
+# Format: { session_id: { "vectorstores": [FAISS], "last_accessed": float, "user_id": int } }
+# user_id is set on upload and checked on every read — prevents cross-user leakage.
 sessions = {}
 SESSION_TIMEOUT = 3600  # 1 hour
 
@@ -142,7 +148,11 @@ def readiness_check():
 # ===============================
 @app.post("/upload")
 @limiter.limit("10/15 minutes")
-async def upload_file(request: Request, file: UploadFile = File(...)):
+async def upload_file(
+    request: Request,
+    file: UploadFile = File(...),
+    current_user: User = Depends(AuthMiddleware.get_current_user)
+):
     if not file.filename.lower().endswith(".pdf"):
         return {"error": "Only PDF files are supported"}
 
@@ -168,7 +178,8 @@ async def upload_file(request: Request, file: UploadFile = File(...)):
 
         sessions[session_id] = {
             "vectorstores": [vectorstore],
-            "last_accessed": time.time()
+            "last_accessed": time.time(),
+            "user_id": current_user.id  # FIX: bind session to uploader
         }
 
         return {
@@ -185,7 +196,11 @@ async def upload_file(request: Request, file: UploadFile = File(...)):
 # ===============================
 @app.post("/ask")
 @limiter.limit("60/15 minutes")
-def ask_question(request: Request, data: AskRequest):
+def ask_question(
+    request: Request,
+    data: AskRequest,
+    current_user: User = Depends(AuthMiddleware.get_current_user)
+):
     cleanup_expired_sessions()
 
     if not data.session_ids:
@@ -195,6 +210,12 @@ def ask_question(request: Request, data: AskRequest):
     for sid in data.session_ids:
         session = sessions.get(sid)
         if session:
+            # FIX: enforce ownership — only allow access to own sessions
+            if session["user_id"] != current_user.id and current_user.role != UserRole.ADMIN:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied: session '{sid}' belongs to another user."
+                )
             session["last_accessed"] = time.time()
             vectorstores.extend(session["vectorstores"])
 
@@ -225,7 +246,11 @@ def ask_question(request: Request, data: AskRequest):
 # ===============================
 @app.post("/summarize")
 @limiter.limit("15/15 minutes")
-def summarize_pdf(request: Request, data: SummarizeRequest):
+def summarize_pdf(
+    request: Request,
+    data: SummarizeRequest,
+    current_user: User = Depends(AuthMiddleware.get_current_user)
+):
     cleanup_expired_sessions()
 
     if not data.session_ids:
@@ -235,6 +260,12 @@ def summarize_pdf(request: Request, data: SummarizeRequest):
     for sid in data.session_ids:
         session = sessions.get(sid)
         if session:
+            # FIX: enforce ownership
+            if session["user_id"] != current_user.id and current_user.role != UserRole.ADMIN:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied: session '{sid}' belongs to another user."
+                )
             vectorstores.extend(session["vectorstores"])
 
     if not vectorstores:
@@ -257,7 +288,11 @@ def summarize_pdf(request: Request, data: SummarizeRequest):
 # ===============================
 @app.post("/compare")
 @limiter.limit("10/15 minutes")
-def compare_documents(request: Request, data: CompareRequest):
+def compare_documents(
+    request: Request,
+    data: CompareRequest,
+    current_user: User = Depends(AuthMiddleware.get_current_user)
+):
     cleanup_expired_sessions()
 
     if len(data.session_ids) < 2:
@@ -267,6 +302,12 @@ def compare_documents(request: Request, data: CompareRequest):
     for sid in data.session_ids:
         session = sessions.get(sid)
         if session:
+            # FIX: enforce ownership
+            if session["user_id"] != current_user.id and current_user.role != UserRole.ADMIN:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied: session '{sid}' belongs to another user."
+                )
             vs = session["vectorstores"][0]
             chunks = vs.similarity_search("main topics", k=4)
             text = "\n".join([c.page_content for c in chunks])


### PR DESCRIPTION
Team Number : Team 146

Description
Fixed a critical cross-user data leakage vulnerability in the RAG service where the global FAISS session store had no ownership binding. Any user who obtained another user's [session_id](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) could query their private PDF data with zero authentication. Sessions are now bound to the authenticated uploader's [user_id](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and all read endpoints enforce ownership before returning data.

Related Issue
Closes #49 

Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 Documentation update
 Code refactoring
 Performance improvement
 Style/UI improvement
Changes Made
Modified [main.py](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
/upload — added [current_user = Depends(AuthMiddleware.get_current_user)](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and stores [session["user_id"] = current_user.id](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on every upload.
/ask — enforces [session["user_id"] == current_user.id](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), returns HTTP 403 if mismatch.
/summarize — same ownership check.
/compare — same ownership check.
Admins ([UserRole.ADMIN](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) bypass the ownership check for support workflows.
Added [demo_bug.py](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — runnable proof-of-concept showing the attack before and after the fix.
Screenshots
Before (Vulnerable)
<img width="674" height="119" alt="Screenshot 2026-02-26 215213" src="https://github.com/user-attachments/assets/d8fa1aec-28ba-47d0-9870-8a84db8f004f" />


After (Fixed)
<img width="1046" height="434" alt="Screenshot 2026-02-26 220725" src="https://github.com/user-attachments/assets/c1569e74-9f06-44f6-8a58-cc4820cc9fcd" />


Verification script output:

STEP 1 — VULNERABLE CODE (before fix)
  Bob attacks: POST /ask  session_ids=[alice_sid]
  SERVER RESPONSE (VULNERABLE):
  CONFIDENTIAL -- Patient: Alice Smith
  SSN: 123-45-6789. Account balance: $84,320.
  [!] BUG: Bob received Alice's CONFIDENTIAL data with zero auth.

STEP 2 — FIXED CODE (after fix)
  Bob attacks: POST /ask  session_ids=[alice_sid]
  SERVER RESPONSE (FIXED):
  403 Forbidden: session belongs to user_id=1, not user_id=2.
  [OK] FIXED: Bob's attack is BLOCKED. Alice's data is protected.
  [OK] Bob can still access his own documents normally.

Testing
 Tested [demo_bug.py](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — attack blocked with 403
 Verified legitimate users can still access their own sessions
 Verified admin role can access any session
 No regressions on /ask, /summarize, /compare
Checklist
 My code follows the project's code style guidelines
 I have performed a self-review of my code
 I have commented my code where necessary
 My changes generate no new warnings
 I have tested my changes thoroughly
 I have read and followed the [CONTRIBUTING.md](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) guidelines

Additional Notes
The fix uses the existing [AuthMiddleware](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [User](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) model already present in [auth](vscode-file://vscode-app/c:/Users/kukad/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — no new dependencies were added. The ownership check is a single if condition per endpoint, adding negligible overhead.